### PR TITLE
Allow access to /info without authentication

### DIFF
--- a/assets_server/views.py
+++ b/assets_server/views.py
@@ -191,7 +191,6 @@ class AssetInfo(APIView):
 
     base_name = 'asset_json'
 
-    @token_authorization
     def get(self, request, file_path):
         """
         Get data for an asset by path


### PR DESCRIPTION
Remove the requirement for an authentication token to request information about an asset.

This will mean you can simply add `/info` to the end of any asset URL to see basic information about it in JSON format. Including dimensions.

QA
--

After getting the server running, visit `xxx-asset-name.ext/info` and see that you can see the info without an auth token.